### PR TITLE
feat: add default reaction to all messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
+.idea/*
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
       <version>5.7.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.38</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/fr/dwunivers/DweacterApp.java
+++ b/src/main/java/fr/dwunivers/DweacterApp.java
@@ -1,5 +1,6 @@
 package fr.dwunivers;
 
+import fr.dwunivers.context.AppContext;
 import fr.dwunivers.services.BotService;
 import fr.dwunivers.services.ConfigurationService;
 import org.slf4j.Logger;
@@ -8,11 +9,12 @@ import org.slf4j.LoggerFactory;
 public class DweacterApp {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DweacterApp.class);
+  private static final AppContext APP_CONTEXT = new AppContext();
 
   public static void main(String[] args) {
     try {
       final String token = ConfigurationService.getDiscordToken();
-      new BotService(token).start();
+      new BotService(token, APP_CONTEXT).start();
     } catch (Exception e) {
       LOGGER.error("Failed to start bot: {}", e.getMessage());
       System.exit(1);

--- a/src/main/java/fr/dwunivers/context/AppContext.java
+++ b/src/main/java/fr/dwunivers/context/AppContext.java
@@ -1,0 +1,13 @@
+package fr.dwunivers.context;
+
+import fr.dwunivers.services.ReactionService;
+import lombok.Getter;
+
+@Getter
+public class AppContext {
+    private final ReactionService reactionService;
+
+    public AppContext() {
+        this.reactionService = new ReactionService();
+    }
+}

--- a/src/main/java/fr/dwunivers/listeners/MessageListener.java
+++ b/src/main/java/fr/dwunivers/listeners/MessageListener.java
@@ -1,18 +1,26 @@
 package fr.dwunivers.listeners;
 
+import fr.dwunivers.context.AppContext;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class MessageListener extends ListenerAdapter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessageListener.class);
+    private final AppContext context;
+
+    public MessageListener(final AppContext context) {
+        this.context = context;
+    }
+
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
         if (!event.getAuthor().isBot()) {
-            Message message = event.getMessage();
-            String content = message.getContentRaw().trim();
-            if (content.equalsIgnoreCase("!ping")) {
-                event.getChannel().sendMessage("Pong!").queue();
-            }
+            final Message message = event.getMessage();
+            context.getReactionService().reactToMessage(message);
         }
     }
 }

--- a/src/main/java/fr/dwunivers/services/BotService.java
+++ b/src/main/java/fr/dwunivers/services/BotService.java
@@ -1,5 +1,6 @@
 package fr.dwunivers.services;
 
+import fr.dwunivers.context.AppContext;
 import fr.dwunivers.listeners.MessageListener;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
@@ -12,21 +13,22 @@ public class BotService {
     private final String token;
     private JDA jda;
     private static final Logger LOGGER = LoggerFactory.getLogger(BotService.class);
+    private final AppContext context;
 
-    public BotService(String token) {
+    public BotService(String token, AppContext context) {
         this.token = token;
+        this.context = context;
     }
 
     public void start() throws Exception {
         LOGGER.info("Starting Dweacter Bot...");
-
         jda = JDABuilder.createDefault(token)
                 .enableIntents(
                         GatewayIntent.GUILD_MESSAGES,
                         GatewayIntent.MESSAGE_CONTENT
                 )
                 .setActivity(Activity.playing("playing with his poppy"))
-                .addEventListeners(new MessageListener())
+                .addEventListeners(new MessageListener(context))
                 .build();
 
         jda.awaitReady();

--- a/src/main/java/fr/dwunivers/services/ReactionService.java
+++ b/src/main/java/fr/dwunivers/services/ReactionService.java
@@ -1,0 +1,24 @@
+package fr.dwunivers.services;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReactionService {
+    private static final Logger LOGGER =  LoggerFactory.getLogger(ReactionService.class);
+    private static final String DEFAULT_EMOJI = "\uD83D\uDD25";
+
+    public Emoji getDefaultEmoji() {
+        return Emoji.fromUnicode(DEFAULT_EMOJI);
+    }
+
+    public void reactToMessage(Message message) {
+        final Emoji emoji = getDefaultEmoji();
+        message.addReaction(emoji).queue(
+                success -> LOGGER.info("Added reaction {} to message {}", emoji, message.getId()),
+                error -> LOGGER.error("Failed to add reaction", error)
+        );
+    }
+
+}


### PR DESCRIPTION
Implements User Story 1 from the "Add reactions to messages" feature.
- Added default 🔥 reaction to every user message
- Introduced AppContext for service management
- Reaction logic fully moved to ReactionService
- Cleaned MessageListener to event-only responsibility
